### PR TITLE
docs: update Rust SDK to Tier 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Pick your language, clone the repo, and start building. Each server implements t
 | 🐍 **Python** | [mcp-python-starter](https://github.com/SamMorrowDrums/mcp-python-starter) | [python-sdk](https://github.com/modelcontextprotocol/python-sdk) (FastMCP) | Tier 1 |
 | 📘 **TypeScript** | [mcp-typescript-starter](https://github.com/SamMorrowDrums/mcp-typescript-starter) | [typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) | Tier 1 |
 | 🐹 **Go** | [mcp-go-starter](https://github.com/SamMorrowDrums/mcp-go-starter) | [go-sdk](https://github.com/modelcontextprotocol/go-sdk) | Tier 1 |
-| 🦀 **Rust** | [mcp-rust-starter](https://github.com/SamMorrowDrums/mcp-rust-starter) | [rust-sdk](https://github.com/modelcontextprotocol/rust-sdk) (rmcp) | TBD |
+| 🦀 **Rust** | [mcp-rust-starter](https://github.com/SamMorrowDrums/mcp-rust-starter) | [rust-sdk](https://github.com/modelcontextprotocol/rust-sdk) (rmcp) | Tier 2 |
 | 💜 **C#** | [mcp-csharp-starter](https://github.com/SamMorrowDrums/mcp-csharp-starter) | [csharp-sdk](https://github.com/modelcontextprotocol/csharp-sdk) | Tier 1 |
 | 🟣 **Kotlin** | [mcp-kotlin-starter](https://github.com/SamMorrowDrums/mcp-kotlin-starter) | [kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk) | TBD |
 | 🐘 **PHP** | [mcp-php-starter](https://github.com/SamMorrowDrums/mcp-php-starter) | [php-sdk](https://github.com/modelcontextprotocol/php-sdk) | Tier 3 |
 
-> **SDK Tiers** indicate feature completeness and maintenance commitment. **Tier 1** SDKs have 100% protocol conformance and full support. **Tier 3** and **TBD** SDKs may have gaps — see each repo for documented limitations. [Learn more about tiers →](https://modelcontextprotocol.io/community/sdk-tiers)
+> **SDK Tiers** indicate feature completeness and maintenance commitment. **Tier 1** SDKs have 100% protocol conformance and full support. **Tier 2** SDKs have most features with active development. **Tier 3** and **TBD** SDKs may have gaps — see each repo for documented limitations. [Learn more about tiers →](https://modelcontextprotocol.io/community/sdk-tiers)
 
 ## 🎯 What You'll Learn
 
@@ -96,7 +96,7 @@ All servers implement the same interface, but some differences exist due to SDK 
 | `prompts.listChanged` / `resources.listChanged` | Some SDKs hardcode `true` when handlers are registered (e.g., TypeScript) | Functionally equivalent |
 | Resource templates (Kotlin) | Kotlin SDK lacks public `addResourceTemplate` API — templates registered as static resources | See [SDK_LIMITATIONS.md](https://github.com/SamMorrowDrums/mcp-kotlin-starter/blob/main/SDK_LIMITATIONS.md) |
 
-Tier 1 SDKs (Python, TypeScript, Go, C#) have the fewest differences. Lower-tier SDKs may have additional gaps — check each repo's `SDK_LIMITATIONS.md` for details.
+Tier 1 SDKs (Python, TypeScript, Go, C#) have the fewest differences. Tier 2 (Rust) is close behind. Lower-tier SDKs may have additional gaps — check each repo's `SDK_LIMITATIONS.md` for details.
 
 ## 📋 Cross-Server Conformance
 


### PR DESCRIPTION
Rust SDK (rmcp) has been promoted to Tier 2 on modelcontextprotocol.io. Updates the tier table and description.